### PR TITLE
Allow empty "default_pool_id"

### DIFF
--- a/neutron_lbaas/extensions/loadbalancerv2.py
+++ b/neutron_lbaas/extensions/loadbalancerv2.py
@@ -227,7 +227,7 @@ RESOURCE_ATTRIBUTE_MAP = {
         'loadbalancers': {'allow_post': False, 'allow_put': False,
                           'is_visible': True},
         'default_pool_id': {'allow_post': False, 'allow_put': False,
-                            'validate': {'type:uuid': None},
+                            'validate': {'type:uuid_or_none': None},
                             'is_visible': True},
         'default_tls_container_ref': {'allow_post': True,
                                       'allow_put': True,


### PR DESCRIPTION
This fix allows to unset the default pool id on the listener. For now neutron returns error message:

```
{"NeutronError": {"message": "Invalid input for default_pool_id. Reason: '' is not a valid UUID.", "type": "HTTPBadRequest", "detail": ""}}
```