### PR TITLE
Only if loadbalancer's status is normal then create pool in db

### DIFF
--- a/neutron_lbaas/services/loadbalancer/plugin.py
+++ b/neutron_lbaas/services/loadbalancer/plugin.py
@@ -868,10 +868,9 @@ class LoadBalancerPluginv2(loadbalancerv2.LoadBalancerPluginBaseV2):
         # blank out the listeners at this point.
         del pool['listener_id']
         pool['listeners'] = []
-        db_pool = self.db.create_pool(context, pool)
         self.db.test_and_set_status(context, models.LoadBalancer,
-                                    db_pool.loadbalancer_id,
-                                    constants.PENDING_UPDATE)
+                                    lb_id, constants.PENDING_UPDATE)
+        db_pool = self.db.create_pool(context, pool)
         for db_l in db_listeners:
             try:
                 self.db.update_listener(context, db_l.id,


### PR DESCRIPTION
When a loadbalancer is in PENDING_UPDATE state, creating a pool with
this lb will return http 409 error with "Invalid state PENDING_UPDATE
of loadbalancer resource LB_ID". But the pool already exists in the
database although the api return this error.

So we shall create a pool in db only if the loadbalancer's state is
normal, wich is consistent with creating listners.

Change-Id: Idb35d4e6ecdc46ff3748768774737b3b01d515f6
Closes-Bug: #1650170